### PR TITLE
Add custom test task

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  buildAndTestjob:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -24,5 +24,7 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
-    - name: 'Test complete'
+    - name: 'Run tests for ConsoleApp'
       run: dotnet test ConsoleAppTests/ConsoleAppTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="ConsoleAppTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude="[Palindromes]*"
+    - name: 'Run tests for Palindromes'
+      run: dotnet test PalindromesTests/PalindromesTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="ConsoleAppTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude=""

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -61,6 +61,21 @@ jobs:
     - name: Upload coverage report artifact
       uses: actions/upload-artifact@v2.2.3
       with:
-        name: CoverageReport # Artifact name        
+        name: CoverageReportForConsoleApp # Artifact name        
         path: ConsoleAppTests/coveragereport # Directory containing files to upload
+    - name: 'ReportGenerator for Palindromes'
+      uses: danielpalme/ReportGenerator-GitHub-Action@5.1.26
+      with:
+        reports: 'ConsoleAppTests/coverage.opencover.xml'
+        targetdir: 'ConsoleAppTests/coveragereport'
+        reporttypes: Html;Badges;Cobertura;MarkdownSummary
+    - name: Publish coverage summary for Palindromes
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        path: coveragereport/Summary.md
+    - name: Upload coverage report artifact for Palindromes
+      uses: actions/upload-artifact@v2.2.3
+      with:
+        name: CoverageReportForPalindromes # Artifact name        
+        path: PalindromesTests/coveragereport # Directory containing files to upload
   

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -31,21 +31,27 @@ jobs:
     - name: 'Run tests for ConsoleApp'
       run: dotnet test ConsoleAppTests/ConsoleAppTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="ConsoleAppTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude="[Palindromes]*"
     - name: 'Run tests for Palindromes'
-      run: dotnet test PalindromesTests/PalindromesTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="ConsoleAppTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude=""
+      run: dotnet test PalindromesTests/PalindromesTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="PalindromesTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude=""
     - name: Display current directory content
       shell: bash
-      run: pwd
+      run: |
+        pwd
+        dir -1
     - name: SwitchDirectories
       shell: bash
-      run: cd ..
+      run: |
+        cd ..
+        dir -1
     - name: Display current directory content after switching
       shell: bash
-      run: pwd
+      run: |
+        pwd
+        dir -1
     - name: 'ReportGenerator for ConsoleApp'
       uses: danielpalme/ReportGenerator-GitHub-Action@5.1.26
       with:
-        reports: 'ConsoleAppTests/coverage.opencover.xml'
-        targetdir: 'ConsoleAppTests/coveragereport'
+        reports: './ConsoleAppTests/coverage.opencover.xml'
+        targetdir: './ConsoleAppTests/coveragereport'
         reporttypes: Html;Badges;Cobertura;MarkdownSummary
     - name: Publish coverage summary
       uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -29,6 +29,11 @@ jobs:
       run: dotnet test ConsoleAppTests/ConsoleAppTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="ConsoleAppTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude="[Palindromes]*"
     - name: 'Run tests for Palindromes'
       run: dotnet test PalindromesTests/PalindromesTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="ConsoleAppTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude=""
+    # - name: SwitchDirectories
+    #   run: 
+    - name: Display the path
+      shell: bash
+      run: echo $PATH
     - name: 'ReportGenerator for ConsoleApp'
       uses: danielpalme/ReportGenerator-GitHub-Action@5.1.26
       with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   buildAndTestjob:
     runs-on: ubuntu-latest
+    defaults:
+        run:
+          working-directory: ./
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -14,6 +14,8 @@ on:
 
 jobs:
   buildAndTestjob:
+    permissions: 
+      pull-requests: write 
     runs-on: ubuntu-latest
     defaults:
         run:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -40,4 +40,9 @@ jobs:
         reports: '**/ConsoleAppTests/coverage.opencover.xml'
         targetdir: 'coveragereport'
         reporttypes: Html;Badges
+    - name: Upload coverage report artifact
+      uses: actions/upload-artifact@v2.2.3
+      with:
+        name: CoverageReport # Artifact name        
+        path: coveragereport # Directory containing files to upload
   

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Test
       run: dotnet test --no-build --verbosity normal
     - name: 'Test complete'
-      run: dotnet test '**/ConsoleAppTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="\ConsoleAppTests\coverage.opencover.xml" -p:CoverletOutputFormat:opencover -p:ThresholdType=Branch -p:Threshold=80'
+      run: dotnet test 'ConsoleAppTests\ConsoleAppTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="\ConsoleAppTests\coverage.opencover.xml" -p:CoverletOutputFormat:opencover -p:ThresholdType=Branch -p:Threshold=80'

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -54,10 +54,10 @@ jobs:
         reports: 'ConsoleAppTests/coverage.opencover.xml'
         targetdir: 'ConsoleAppTests/coveragereport'
         reporttypes: Html;Badges;Cobertura;MarkdownSummary
-    - name: Publish coverage summary
+    - name: Publish coverage summary for ConsoleAppTests
       uses: marocchino/sticky-pull-request-comment@v2
       with:
-        path: coveragereport/Summary.md
+        path: ConsoleAppTests/coveragereport/Summary.md
     - name: Upload coverage report artifact
       uses: actions/upload-artifact@v2.2.3
       with:
@@ -72,7 +72,7 @@ jobs:
     - name: Publish coverage summary for Palindromes
       uses: marocchino/sticky-pull-request-comment@v2
       with:
-        path: coveragereport/Summary.md
+        path: PalindromesTests/coveragereport/Summary.md
     - name: Upload coverage report artifact for Palindromes
       uses: actions/upload-artifact@v2.2.3
       with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -31,9 +31,9 @@ jobs:
       run: dotnet test PalindromesTests/PalindromesTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="ConsoleAppTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude=""
     # - name: SwitchDirectories
     #   run: 
-    - name: Display the path
+    - name: Display current directory content
       shell: bash
-      run: echo $PATH
+      run: dir
     - name: 'ReportGenerator for ConsoleApp'
       uses: danielpalme/ReportGenerator-GitHub-Action@5.1.26
       with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -50,8 +50,8 @@ jobs:
     - name: 'ReportGenerator for ConsoleApp'
       uses: danielpalme/ReportGenerator-GitHub-Action@5.1.26
       with:
-        reports: './ConsoleAppTests/coverage.opencover.xml'
-        targetdir: './ConsoleAppTests/coveragereport'
+        reports: 'ConsoleAppTests/coverage.opencover.xml'
+        targetdir: 'ConsoleAppTests/coveragereport'
         reporttypes: Html;Badges;Cobertura;MarkdownSummary
     - name: Publish coverage summary
       uses: marocchino/sticky-pull-request-comment@v2
@@ -61,5 +61,5 @@ jobs:
       uses: actions/upload-artifact@v2.2.3
       with:
         name: CoverageReport # Artifact name        
-        path: coveragereport # Directory containing files to upload
+        path: ConsoleAppTests/coveragereport # Directory containing files to upload
   

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -9,12 +9,9 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
-
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -29,9 +29,9 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: 'Run tests for ConsoleApp'
-      run: dotnet test ConsoleAppTests/ConsoleAppTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="ConsoleAppTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude="[Palindromes]*"
+      run: dotnet test ConsoleAppTests/ConsoleAppTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude="[Palindromes]*"
     - name: 'Run tests for Palindromes'
-      run: dotnet test PalindromesTests/PalindromesTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="PalindromesTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude=""
+      run: dotnet test PalindromesTests/PalindromesTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude=""
     - name: Display current directory content
       shell: bash
       run: |

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Test
       run: dotnet test --no-build --verbosity normal
     - name: 'Test complete'
-      run: dotnet test 'ConsoleAppTests\ConsoleAppTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="\ConsoleAppTests\coverage.opencover.xml" -p:CoverletOutputFormat:opencover -p:ThresholdType=Branch -p:Threshold=80'
+      run: dotnet test ConsoleAppTests/ConsoleAppTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="ConsoleAppTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude="[Palindromes]*"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
         run:
-          working-directory: $ {{github_workspace}}
+          working-directory: ${{github.workspace}}
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -2,6 +2,9 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 name: 'Build and Test All projects'
 
+env:
+  ACTIONS_RUNNER_DEBUG : true
+
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -32,8 +32,8 @@ jobs:
       run: dotnet test ConsoleAppTests/ConsoleAppTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="ConsoleAppTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude="[Palindromes]*"
     - name: 'Run tests for Palindromes'
       run: dotnet test PalindromesTests/PalindromesTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="ConsoleAppTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude=""
-    # - name: SwitchDirectories
-    #   run: 
+    - name: SwitchDirectories
+      run: cd ..
     - name: Display current directory content
       shell: bash
       run: dir

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -28,3 +28,9 @@ jobs:
       run: dotnet test ConsoleAppTests/ConsoleAppTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="ConsoleAppTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude="[Palindromes]*"
     - name: 'Run tests for Palindromes'
       run: dotnet test PalindromesTests/PalindromesTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="ConsoleAppTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude=""
+    - name: 'ReportGenerator for ConsoleApp'
+      uses: danielpalme/ReportGenerator-GitHub-Action@5.1.26
+      with:
+        reports: 'ConsoleAppTests/coverage.opencover.xml'
+        targetdir: 'coveragereport'
+  

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
         run:
-          working-directory: ${{github.workspace}}
+          working-directory: .
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -47,6 +47,7 @@ jobs:
       run: |
         pwd
         dir -1
+        find . -type f
     - name: 'ReportGenerator for ConsoleApp'
       uses: danielpalme/ReportGenerator-GitHub-Action@5.1.26
       with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -66,8 +66,8 @@ jobs:
     - name: 'ReportGenerator for Palindromes'
       uses: danielpalme/ReportGenerator-GitHub-Action@5.1.26
       with:
-        reports: 'ConsoleAppTests/coverage.opencover.xml'
-        targetdir: 'ConsoleAppTests/coveragereport'
+        reports: 'PalindromesTests/coverage.opencover.xml'
+        targetdir: 'PalindromesTests/coveragereport'
         reporttypes: Html;Badges;Cobertura;MarkdownSummary
     - name: Publish coverage summary for Palindromes
       uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
         run:
-          working-directory: $github_workspace
+          working-directory: $ {{github_workspace}}
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -22,8 +22,6 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore
-    - name: Test
-      run: dotnet test --no-build --verbosity normal
     - name: 'Run tests for ConsoleApp'
       run: dotnet test ConsoleAppTests/ConsoleAppTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="ConsoleAppTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude="[Palindromes]*"
     - name: 'Run tests for Palindromes'

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -32,16 +32,20 @@ jobs:
       run: dotnet test ConsoleAppTests/ConsoleAppTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="ConsoleAppTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude="[Palindromes]*"
     - name: 'Run tests for Palindromes'
       run: dotnet test PalindromesTests/PalindromesTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="ConsoleAppTests/coverage.opencover.xml" -p:CoverletOutputFormat=opencover -p:ThresholdType=Branch -p:Threshold=63 -p:Exclude=""
-    - name: SwitchDirectories
-      run: cd ..
     - name: Display current directory content
       shell: bash
-      run: dir
+      run: pwd
+    - name: SwitchDirectories
+      shell: bash
+      run: cd ..
+    - name: Display current directory content after switching
+      shell: bash
+      run: pwd
     - name: 'ReportGenerator for ConsoleApp'
       uses: danielpalme/ReportGenerator-GitHub-Action@5.1.26
       with:
-        reports: '**/ConsoleAppTests/coverage.opencover.xml'
-        targetdir: 'coveragereport'
+        reports: 'ConsoleAppTests/coverage.opencover.xml'
+        targetdir: 'ConsoleAppTests/coveragereport'
         reporttypes: Html;Badges;Cobertura;MarkdownSummary
     - name: Publish coverage summary
       uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -59,6 +59,7 @@ jobs:
     - name: Publish coverage summary for ConsoleAppTests
       uses: marocchino/sticky-pull-request-comment@v2
       with:
+        header: Summary for Console App
         path: ConsoleAppTests/coveragereport/Summary.md
     - name: Upload coverage report artifact
       uses: actions/upload-artifact@v2.2.3
@@ -74,6 +75,7 @@ jobs:
     - name: Publish coverage summary for Palindromes
       uses: marocchino/sticky-pull-request-comment@v2
       with:
+        header: Summary for Palindromes Library
         path: PalindromesTests/coveragereport/Summary.md
     - name: Upload coverage report artifact for Palindromes
       uses: actions/upload-artifact@v2.2.3

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Test
       run: dotnet test --no-build --verbosity normal
     - name: 'Test complete'
-      run: dotnet test '**/ConsoleAppTests.csproj' --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="\ConsoleAppTests\coverage.opencover.xml" -p:CoverletOutputFormat:opencover -p:ThresholdType=Branch -p:Threshold=80'
+      run: dotnet test '**/ConsoleAppTests.csproj --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="\ConsoleAppTests\coverage.opencover.xml" -p:CoverletOutputFormat:opencover -p:ThresholdType=Branch -p:Threshold=80'

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -31,6 +31,6 @@ jobs:
     - name: 'ReportGenerator for ConsoleApp'
       uses: danielpalme/ReportGenerator-GitHub-Action@5.1.26
       with:
-        reports: 'ConsoleAppTests/coverage.opencover.xml'
+        reports: './ConsoleAppTests/coverage.opencover.xml'
         targetdir: 'coveragereport'
   

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -42,7 +42,11 @@ jobs:
       with:
         reports: '**/ConsoleAppTests/coverage.opencover.xml'
         targetdir: 'coveragereport'
-        reporttypes: Html;Badges
+        reporttypes: Html;Badges;Cobertura;MarkdownSummary
+    - name: Publish coverage summary
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        path: coveragereport/Summary.md
     - name: Upload coverage report artifact
       uses: actions/upload-artifact@v2.2.3
       with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -24,3 +24,5 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
+    - name: 'Test complete'
+      run: dotnet test '**/ConsoleAppTests.csproj' --configuration:Release -p:CollectCoverage=true -p:CoverletOutput="\ConsoleAppTests\coverage.opencover.xml" -p:CoverletOutputFormat:opencover -p:ThresholdType=Branch -p:Threshold=80'

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
         run:
-          working-directory: ./
+          working-directory: $github_workspace
     steps:
     - uses: actions/checkout@v3
     - name: Setup .NET

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -37,6 +37,7 @@ jobs:
     - name: 'ReportGenerator for ConsoleApp'
       uses: danielpalme/ReportGenerator-GitHub-Action@5.1.26
       with:
-        reports: './ConsoleAppTests/coverage.opencover.xml'
+        reports: '**/ConsoleAppTests/coverage.opencover.xml'
         targetdir: 'coveragereport'
+        reporttypes: Html;Badges
   

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,8 @@
     "files.autoSave": "onWindowChange",
     "editor.stickyTabStops": true,
     "editor.detectIndentation": false,
-    "files.eol": "\n"
+    "files.eol": "\n",
+    "github-actions.workflows.pinned.workflows": [
+        ".github/workflows/ci-workflow.yml"
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![.NET](https://github.com/disouzam/Palindromes/actions/workflows/ci-workflow.yml/badge.svg)](https://github.com/disouzam/Palindromes/actions/workflows/ci-workflow.yml)
+[![Build and Test All projects](https://github.com/disouzam/Palindromes/actions/workflows/ci-workflow.yml/badge.svg)](https://github.com/disouzam/Palindromes/actions/workflows/ci-workflow.yml)
 
 # PalindromicNumbers
 This repository contains code related to some exercises and experimentation around palindromic numbers


### PR DESCRIPTION
1. **20152c9** Fixed status badge again
1. **bd426d0** Removed extra blank lines on workflow file
1. **6ffb1c1** Added a new test with custom command based on previous experience in Azure DevOps and in some docs
    References:
    - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defaultsrun
1. **f45f9a2** Fixed command syntax for task Test complete
1. **0f52b8f** Add full path to action that run a complete version of tests
1. **c6070f1** Fixed command to run a custom action to run tests and generate coverage report
1. **6fa607e** Renamed main job, action for ConsoleApp tests execution and added a new task to run Palindromes tests
    References:
    - https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow
    - https://docs.github.com/en/actions/creating-actions/about-custom-actions
    - https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
1. **750f42e** Added report generator action
    Reference:
    - https://github.com/marketplace/actions/reportgenerator
1. **399d078** Fixed path to opencover report
1. **80094b9** Removed generic test action added on action creation in GitHub UI
1. **db26998** Added a default working directory
    References:
    - https://docs.github.com/en/actions/learn-github-actions/essential-features-of-github-actions
    - https://stackoverflow.com/questions/58139175/running-actions-in-another-directory
1. **69cf584** Added an action to display path
1. **95f0cd7** Trying another configuration of ReportGenerator action after playing with Daniel Palme online tool at
    https://reportgenerator.io/usage
1. **0244188** Displaying current directory content
1. **f54999f** Added another action to upload coverage report artifact
1. **4a7911b** Setting ACTIONS_RUNNER_DEBUG variable to true
    Reference:
    - https://docs.github.com/en/actions/learn-github-actions/variables
1. **84b91cb** Setting up working-directory
1. **4f63343** Setting up working-directory
    New references:
    - https://docs.github.com/en/actions/learn-github-actions/variables
1. **23c5780** Another tentative of getting syntax for working directory correct
1. **b95b727** Another tentative of getting syntax for working directory correct - 2
1. **a87faa0** Switching directories before installing reportgenerator
1. **a6b3f47** Added action stricky-pull-request-comment
    Reference:
    - https://github.com/danielpalme/ReportGenerator-GitHub-Action/issues/7
1. **ffee250** Pinned github actions workflow in VS Code
1. **a1c5bb5** Fixed action to display current directory and fixed path to report generator
1. **1e3d731** Miscellaneous changes and fix in Run tests for Palindromes action
1. **ffb9640** Still trying to get GitHub actions syntax correct
1. **5e01a44** List all files under GitHub workspace
1. **52c57a6** Fixed path for parameter CoverletOutput in actions Run tests for Palindromes and Run tests for ConsoleApp
1. **723612f** Added replicas of actions for Palindromes tests
1. **e744908** Fixed task ReportGeneratorForPalindromes - path was wrong